### PR TITLE
refactor: remove unecessary dependency features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,16 +59,16 @@ full = ["test-utils"]
 
 [dependencies]
 itertools = "0.14"
-opentelemetry_0_26 = { package = "opentelemetry", version = "0.26", optional = true }
-opentelemetry_0_27 = { package = "opentelemetry", version = "0.27", optional = true }
-opentelemetry_0_28 = { package = "opentelemetry", version = "0.28", optional = true }
-opentelemetry_0_29 = { package = "opentelemetry", version = "0.29", optional = true }
-opentelemetry_0_30 = { package = "opentelemetry", version = "0.30", optional = true }
+opentelemetry_0_26 = { package = "opentelemetry", version = "0.26", default-features = false, features = ["metrics"], optional = true }
+opentelemetry_0_27 = { package = "opentelemetry", version = "0.27", default-features = false, features = ["metrics", "trace"], optional = true }
+opentelemetry_0_28 = { package = "opentelemetry", version = "0.28", default-features = false, features = ["metrics"], optional = true }
+opentelemetry_0_29 = { package = "opentelemetry", version = "0.29", default-features = false, features = ["futures", "metrics"], optional = true }
+opentelemetry_0_30 = { package = "opentelemetry", version = "0.30", default-features = false, features = ["futures", "metrics"], optional = true }
 parking_lot = "0.12"
-prometheus-client_0_22 = { package = "prometheus-client", version = "0.22", optional = true }
-prometheus-client_0_23 = { package = "prometheus-client", version = "0.23", optional = true }
-prometheus_0_13 = { package = "prometheus", version = "0.13", optional = true }
-prometheus_0_14 = { package = "prometheus", version = "0.14", optional = true }
+prometheus-client_0_22 = { package = "prometheus-client", version = "0.22", default-features = false, optional = true }
+prometheus-client_0_23 = { package = "prometheus-client", version = "0.23", default-features = false, optional = true }
+prometheus_0_13 = { package = "prometheus", version = "0.13", default-features = false, optional = true }
+prometheus_0_14 = { package = "prometheus", version = "0.14", default-features = false, optional = true }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## What's changed and what's your intention?

I removed unecessary features from dependencies.

I first noticed this after integrating mixtrics and having dependabot security alert about `prometheus_0_13` security issue with `protobuf` feature (https://github.com/rustsec/advisory-db/blob/5c87b926136ad8b374e0025d5908f496d5249d43/crates/protobuf/RUSTSEC-2024-0437.md), while it was explicitely disabled in my project.

## Checklist

- [X] I have written the necessary rustdoc comments (there is no real doc changes)
- [X] I have added the necessary unit tests and integration tests (tests are passing)
- [X] I have passed `make all` in my local environment.

## Related issues or PRs (optional)
