### PR TITLE
chore: migrate HawkEye to v7

### DIFF
--- a/.licenserc.toml
+++ b/.licenserc.toml
@@ -1,7 +1,9 @@
-headerPath = "Apache-2.0.txt"
+[header]
+builtin = "Apache-2.0"
 
+[files]
 includes = ['**/*.rs']
 
-[properties]
-copyrightOwner = "mixtrics Project Authors"
-inceptionYear = 2025
+[props]
+copyright_owner = "mixtrics Project Authors"
+inception_year = 2025


### PR DESCRIPTION
## What's changed and what's your intention?

Migrate the HawkEye configuration to v7 so the repository can continue installing and using the latest release. HawkEye v7 validates 19 files with 0 changes, 0 conflicts, and 0 unsupported files.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [ ] I have passed `make all` in my local environment.

No code or public API changed, so no new rustdoc or tests are necessary.

## Related issues or PRs (optional)

N/A